### PR TITLE
ci: validate の paths filter をジョブ内部化して全 PR で build を報告する

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,12 +1,12 @@
 name: validate
 
+# build ジョブは全 PR で起動し required status check を必ず報告する。
+# workflow-level の paths filter を使うと、無関係な PR (例: github-actions 更新) では
+# workflow 自体が発火せず required check が「待ち」で詰まる。それを避けるため paths 判定は
+# ジョブ内部で行い、rust に無関係な変更では重い cargo ステップだけを skip する。
 on:
   pull_request:
     branches: ["main"]
-    paths:
-      - "src/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
 
 permissions:
   contents: read
@@ -29,11 +29,27 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      # rust に関わる変更があるかを PR 差分から判定する。無ければ以降を skip する。
+      - name: Detect rust changes
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          filters: |
+            rust:
+              - 'src/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+
       - name: Build
+        if: steps.filter.outputs.rust == 'true'
         run: cargo build --verbose
       - name: Check
+        if: steps.filter.outputs.rust == 'true'
         run: cargo check --verbose
       - name: Clippy
+        if: steps.filter.outputs.rust == 'true'
         run: cargo clippy --verbose
       - name: Run tests
+        if: steps.filter.outputs.rust == 'true'
         run: cargo test --verbose


### PR DESCRIPTION
## 概要

`validate.yml` の paths filter を workflow-level からジョブ内部へ移し、build ジョブを全 PR で起動して required status check を必ず報告するようにする。dependabot auto-merge 導入の前提整備。

## 背景

morse を rust-cli auto-merge グループへ載せる計画（github_central 設計文書 `document/design/rust_cli_automerge_group.md`）で、`build` を ruleset の required status check にしたい。ところが現状の `validate.yml` は:

```yaml
on:
  pull_request:
    paths: ["src/**", "Cargo.toml", "Cargo.lock"]
```

と workflow-level の paths filter を持つため、rust に無関係な PR（例: github-actions の dependabot 更新）では **workflow 自体が発火せず** build の status が報告されない。

## 課題

- `build` を required にすると、上記の非 rust PR で required check が「Expected — waiting」のまま**マージが永久に詰まる**。
- かといって `build` を required から外すと、cargo 更新が**ビルド未検証のまま auto-merge**され危険。

## 目標

- 必須: build を全 PR で起動し required check を必ず報告する（詰まり回避）
- 必須: rust 無関係な PR では重い cargo ステップを走らせず CI コストを従来同等に保つ
- 範囲外: build の中身（cargo build/check/clippy/test）の変更

## 採用手法

workflow-level の `on.paths` を撤去し、paths 判定をジョブ内部の `dorny/paths-filter`（SHA 固定）へ移す。build ジョブは常に起動して check を報告し、`steps.filter.outputs.rust == 'true'` のときだけ cargo ステップを実行する。

| 選択肢 | 内容 | 採否 |
|---|---|---|
| 内部 paths-filter + step gating | ジョブ常時起動・check 常時報告・重い処理のみ skip | 採用。詰まらず CI コストも据え置き |
| on.paths を単純撤去 | 全 PR で毎回フル build | 不採用。doc 変更でも matrix build 全走行 |
| build を required にしない | ruleset を緩める | 不採用。cargo 更新がビルド未検証で自動マージ |

## 変更箇所

- `.github/workflows/validate.yml`: `on.paths` を撤去。`dorny/paths-filter@7b450fff…`（v4.0.2, SHA 固定）で rust 変更を検出し、cargo 各ステップを `if` で gate

## 妥協と制限

- 非 rust PR でも build ジョブの起動（checkout + paths-filter, 数十秒）は発生する。cargo ステップは skip されるため実質コストは軽微。

## 検証方法

- `actionlint` / `ghalint` / `zizmor` をローカル実行し pass
- 本 PR は `.github/workflows/` のみ変更のため、新ロジックで `build (ubuntu/macos-latest)` が **起動し cargo ステップは skip される**挙動を CI 上で確認できる（詰まり回避の実証）
- cargo ステップが実走行する経路は、次回の cargo dependabot PR で確認

## 確認事項

- ⚠️ この修正後に github_central 側で morse の `required_status_checks` に `build (ubuntu-latest)` / `build (macos-latest)` を追加する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
